### PR TITLE
Port to AdwAboutWindow and use gnome 44 runtime

### DIFF
--- a/io.github.lainsce.Countdown.json
+++ b/io.github.lainsce.Countdown.json
@@ -1,7 +1,7 @@
 {
     "app-id" : "io.github.lainsce.Countdown.Devel",
     "runtime" : "org.gnome.Sdk",
-    "runtime-version" : "42",
+    "runtime-version" : "44",
     "sdk" : "org.gnome.Sdk",
     "command" : "io.github.lainsce.Countdown",
     "finish-args" : [

--- a/src/Widgets/mainwindow.ui.vala
+++ b/src/Widgets/mainwindow.ui.vala
@@ -147,19 +147,18 @@ namespace Countdown {
             };
 
             var program_name = "Countdown" + Config.NAME_SUFFIX;
-            Gtk.show_about_dialog (this,
-                                   "program-name", program_name,
-                                   "logo-icon-name", Config.APP_ID,
-                                   "version", Config.VERSION,
-                                   "comments", _("Track events until they happen or since they happened."),
-                                   "copyright", COPYRIGHT,
-                                   "authors", AUTHORS,
-                                   "artists", null,
-                                   "license-type", Gtk.License.GPL_3_0,
-                                   "wrap-license", false,
-                                   // TRANSLATORS: 'Name <email@domain.com>' or 'Name https://website.example'
-                                   "translator-credits", _("translator-credits"),
-                                   null);
+            var about_window = new Adw.AboutWindow ();
+
+            about_window.set_application_icon(Config.APP_ID);
+            about_window.set_version(Config.VERSION);
+            about_window.set_comments(_("Track events until they happen or since they happened."));
+            about_window.set_copyright(COPYRIGHT);
+            about_window.set_developers(AUTHORS);
+            about_window.set_license_type(Gtk.License.GPL_3_0);
+            about_window.set_translator_credits(_("translator-credits"));
+
+            about_window.set_transient_for(this);
+            about_window.present();
         }
 	}
 }


### PR DESCRIPTION
Ports the about section to use `AdwAboutWindow` and also bumps the gnome runtime used in the flatpak manifest to version 44

![Screenshot from 2023-04-23 00-34-56](https://user-images.githubusercontent.com/60044824/233810515-27f3ccea-6584-47da-a021-66bdefb605db.png)
