### PR TITLE
Two patches related to UI

### DIFF
--- a/src/Widgets/dialog.ui
+++ b/src/Widgets/dialog.ui
@@ -75,7 +75,7 @@
                       <object class="GtkEntry" id="event_date_day_entry">
                         <property name="valign">center</property>
                         <property name="max_width_chars">2</property>
-                        <property name="placeholder_text">DD</property>
+                        <property name="placeholder_text" translatable="yes">DD</property>
                       </object>
                     </child>
                     <child>
@@ -87,7 +87,7 @@
                       <object class="GtkEntry" id="event_date_month_entry">
                         <property name="valign">center</property>
                         <property name="max_width_chars">2</property>
-                        <property name="placeholder_text">MM</property>
+                        <property name="placeholder_text" translatable="yes">MM</property>
                       </object>
                     </child>
                     <child>
@@ -99,7 +99,7 @@
                       <object class="GtkEntry" id="event_date_year_entry">
                         <property name="valign">center</property>
                         <property name="max_width_chars">4</property>
-                        <property name="placeholder_text">YYYY</property>
+                        <property name="placeholder_text" translatable="yes">YYYY</property>
                         <property name="activates-default">1</property>
                       </object>
                     </child>

--- a/src/Widgets/mainwindow.ui.vala
+++ b/src/Widgets/mainwindow.ui.vala
@@ -146,9 +146,10 @@ namespace Countdown {
                 null
             };
 
-            var program_name = "Countdown" + Config.NAME_SUFFIX;
+            var program_name = _("Countdown") + Config.NAME_SUFFIX;
             var about_window = new Adw.AboutWindow ();
 
+            about_window.set_application_name(program_name);
             about_window.set_application_icon(Config.APP_ID);
             about_window.set_version(Config.VERSION);
             about_window.set_comments(_("Track events until they happen or since they happened."));


### PR DESCRIPTION
**UI: Make application name translatable**

- Make application name translatable
- Show application name on the about page

**UI: Mark three strings translatable**

- DD, MM, YYYY strings should be translatable